### PR TITLE
Bump .NET Framework to 4.8

### DIFF
--- a/ThreatCheck/ThreatCheck/App.config
+++ b/ThreatCheck/ThreatCheck/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/ThreatCheck/ThreatCheck/ThreatCheck.csproj
+++ b/ThreatCheck/ThreatCheck/ThreatCheck.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ThreatCheck</RootNamespace>
     <AssemblyName>ThreatCheck</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,10 +33,11 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.8.0\lib\net40\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.9.1.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.9.1\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ThreatCheck/ThreatCheck/packages.config
+++ b/ThreatCheck/ThreatCheck/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.8.0" targetFramework="net40" />
+  <package id="CommandLineParser" version="2.9.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
.NET Framework 4.0 is no longer supported. This PR:
* Bumps .NET Framework 4.0 -> 4.8
* Bumps `CommandLineParser` to 4.8 target and version bumps it