### PR TITLE
Added support to pass custom folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ C:\>ThreatCheck.exe --help
   -e, --engine    (Default: Defender) Scanning engine. Options: Defender, AMSI
   -f, --file      Analyze a file on disk
   -u, --url       Analyze a file from a URL
+  -b, --base-folder    (Default: C:\Temp) The path to the folder where the file will be copied and analyzed. Should be a Defender exclusion folder
   --help          Display this help screen.
   --version       Display version information.
 ```

--- a/README.md
+++ b/README.md
@@ -36,3 +36,33 @@ C:\Users\Rasta>ThreatCheck.exe -f Downloads\Grunt.bin -e AMSI
 000000E0   00 79 00 70 00 74 00 65  00 64 00 4D 00 65 00 73   ·y·p·t·e·d·M·e·s
 000000F0   00 73 00 61 00 67 00 65  00 22 00 3A 00 22 00 7B   ·s·a·g·e·"·:·"·{
 ```
+### File locked by Defender error
+```text
+ThreatCheck.exe -f .\shell.exe
+[*] C:\Temp doesn't exist. Creating it...
+[+] Target file size: 73802 bytes
+[+] Analyzing...
+[*] Testing 36901 bytes
+[*] No threat found, increasing size
+[*] Testing 55351 bytes
+[*] Threat found, splitting
+[*] Testing 46126 bytes
+[*] No threat found, increasing size
+[*] Testing 59964 bytes
+[*] Threat found, splitting
+[*] Testing 53045 bytes
+
+Unhandled Exception: System.IO.IOException: The process cannot access the file 'C:\Temp\file.exe' because it is being used by another process.
+   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
+   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
+   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
+   at System.IO.File.InternalWriteAllBytes(String path, Byte[] bytes, Boolean checkHost)
+   at ThreatCheck.Defender.AnalyzeFile() in C:\Users\*****\Downloads\ThreatCheck-master\ThreatCheck-master\ThreatCheck\ThreatCheck\Defender\Defender.cs:line 55
+   at ThreatCheck.Program.ScanWithDefender(Byte[] file) in C:\Users\*****\Downloads\ThreatCheck-master\ThreatCheck-master\ThreatCheck\ThreatCheck\Program.cs:line 114
+   at ThreatCheck.Program.RunOptions(Options opts) in C:\Users\*****\Downloads\ThreatCheck-master\ThreatCheck-master\ThreatCheck\ThreatCheck\Program.cs:line 85
+   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
+   at ThreatCheck.Program.Main(String[] args) in C:\Users\*****\Downloads\ThreatCheck-master\ThreatCheck-master\ThreatCheck\ThreatCheck\Program.cs:line 35
+```
+In this case set an exclusion folder in Windows Defender and pass the path as parameter, e.g.
+```text
+ThreatCheck.exe -f .\shell.exe -b "C:\excluded_defender_folder"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ C:\Users\Rasta>ThreatCheck.exe -f Downloads\Grunt.bin -e AMSI
 000000E0   00 79 00 70 00 74 00 65  00 64 00 4D 00 65 00 73   ·y·p·t·e·d·M·e·s
 000000F0   00 73 00 61 00 67 00 65  00 22 00 3A 00 22 00 7B   ·s·a·g·e·"·:·"·{
 ```
-### File locked by Defender error
+### Bypaas file locked by Defender error
 ```text
 ThreatCheck.exe -f .\shell.exe
 [*] C:\Temp doesn't exist. Creating it...

--- a/ThreatCheck/ThreatCheck/Defender/Defender.cs
+++ b/ThreatCheck/ThreatCheck/Defender/Defender.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -10,22 +10,24 @@ namespace ThreatCheck
         byte[] FileBytes;
         string FilePath;
 
-        public Defender(byte[] file)
+        public Defender(byte[] file, string base_folder)
         {
             FileBytes = file;
+            FilePath = base_folder;
         }
 
         public void AnalyzeFile()
         {
-            if (!Directory.Exists(@"C:\Temp"))
+            if (!Directory.Exists(FilePath))
             {
 #if DEBUG
-                CustomConsole.WriteDebug(@"C:\Temp doesn't exist. Creating it...");
+                CustomConsole.WriteDebug(FilePath + " doesn't exist. Creating it...");
 #endif
-                Directory.CreateDirectory(@"C:\Temp");
+                Directory.CreateDirectory(FilePath);
+               
             }
 
-            FilePath = Path.Combine(@"C:\Temp", "file.exe");
+            FilePath = Path.Combine(FilePath, "file.exe");
             File.WriteAllBytes(FilePath, FileBytes);
 
             var status = ScanFile(FilePath);
@@ -75,6 +77,7 @@ namespace ThreatCheck
                     Buffer.BlockCopy(tmpArray, 0, splitArray, 0, tmpArray.Length);
                 }
             }
+            if(File.Exists(FilePath)) File.Delete(FilePath);// clean
         }
 
         public DefenderScanResult ScanFile(string file, bool getsig = false)

--- a/ThreatCheck/ThreatCheck/Program.cs
+++ b/ThreatCheck/ThreatCheck/Program.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 using System;
 using System.Collections.Generic;
@@ -20,6 +20,10 @@ namespace ThreatCheck
 
             [Option('u', "url", Required = false, HelpText = "Analyze a file from a URL")]
             public string InUrl { get; set; }
+
+            [Option('b', "base-folder", Default = @"C:\Temp", Required = false, HelpText = "The path to the " +
+                @"folder where the file will be copied and analyzed. Should be a Defender exclusion folder")]
+            public string InBF { get; set; }
         }
 
         public enum ScanningEngine
@@ -46,6 +50,8 @@ namespace ThreatCheck
         static void RunOptions(Options opts)
         {
             var file = new byte[] { };
+            string base_folder = "";
+
             var engine = (ScanningEngine)Enum.Parse(typeof(ScanningEngine), opts.Engine, true);
 
             if (!string.IsNullOrEmpty(opts.InUrl))
@@ -66,6 +72,7 @@ namespace ThreatCheck
                 if (File.Exists(opts.InFile))
                 {
                     file = File.ReadAllBytes(opts.InFile);
+                    base_folder = opts.InBF;
                 }
                 else
                 {
@@ -82,7 +89,7 @@ namespace ThreatCheck
             switch (engine)
             {
                 case ScanningEngine.Defender:
-                    ScanWithDefender(file);
+                    ScanWithDefender(file,base_folder);
                     break;
                 case ScanningEngine.Amsi:
                     ScanWithAmsi(file);
@@ -108,9 +115,9 @@ namespace ThreatCheck
             }
         }
 
-        static void ScanWithDefender(byte[] file)
+        static void ScanWithDefender(byte[] file, string bf)
         {
-            var defender = new Defender(file);
+            var defender = new Defender(file, bf);
             defender.AnalyzeFile();
         }
 

--- a/ThreatCheck/ThreatCheck/Properties/AssemblyInfo.cs
+++ b/ThreatCheck/ThreatCheck/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -10,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ThreatCheck")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyCopyright("Copyright ©  2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]


### PR DESCRIPTION
Since Windows Defender detects the copied file being analyzed in C:\Temp, I added support to pass a parameter (-b) used to set a custom path. Follows the error I encountered
![threatcheck_error](https://github.com/rasta-mouse/ThreatCheck/assets/24391516/fe5491a8-ddbd-4969-9cfb-57876ed49eeb)
