### PR TITLE
Improved hex dumping method

### DIFF
--- a/ThreatCheck/ThreatCheck/Core/Helpers.cs
+++ b/ThreatCheck/ThreatCheck/Core/Helpers.cs
@@ -5,69 +5,57 @@ namespace ThreatCheck
 {
     class Helpers
     {
-        public static void HexDump(byte[] bytes)
+        public static void HexDump(byte[] bytes, int end)
         {
-            var bytesPerLine = 16;
 
-            var hexChars = "0123456789ABCDEF".ToCharArray();
-
-            var firstHexColumn =
-                  8                     // 8 characters for the address
-                + 3;                    // 3 spaces
-
-            var firstCharColumn = firstHexColumn
-                + bytesPerLine * 3                  // - 2 digit for the hexadecimal value and 1 space
-                + (bytesPerLine - 1) / 8            // - 1 extra space every 8 characters from the 9th
-                + 2;                                // 2 spaces 
-
-            var lineLength = firstCharColumn
-                + bytesPerLine                      // - characters to show the ascii value
-                + Environment.NewLine.Length;       // Carriage return and line feed (should normally be 2)
-
-            var line = (new string(' ', lineLength - Environment.NewLine.Length) + Environment.NewLine).ToCharArray();
-            var expectedLines = (bytes.Length + bytesPerLine - 1) / bytesPerLine;
-            var result = new StringBuilder(expectedLines * lineLength);
-
-            for (int i = 0; i < bytes.Length; i += bytesPerLine)
+            int fileoffset = end - bytes.Length;
+            int offset = 0;
+            while (offset < bytes.Length)
             {
-                line[0] = hexChars[(i >> 28) & 0xF];
-                line[1] = hexChars[(i >> 24) & 0xF];
-                line[2] = hexChars[(i >> 20) & 0xF];
-                line[3] = hexChars[(i >> 16) & 0xF];
-                line[4] = hexChars[(i >> 12) & 0xF];
-                line[5] = hexChars[(i >> 8) & 0xF];
-                line[6] = hexChars[(i >> 4) & 0xF];
-                line[7] = hexChars[(i >> 0) & 0xF];
-
-                var hexColumn = firstHexColumn;
-                var charColumn = firstCharColumn;
-
-                for (var j = 0; j < bytesPerLine; j++)
+                int printOffset = fileoffset + offset;
+                if (end == 0)
                 {
-                    if (j > 0 && (j & 7) == 0) hexColumn++;
-                    if (i + j >= bytes.Length)
+                    printOffset = 0;
+                }
+                Console.Write($"{printOffset:X8}   ");
+
+                // Print 16 bytes as hex
+                for (int i = 0; i < 16; i++)
+                {
+                    if (offset + i < bytes.Length)
                     {
-                        line[hexColumn] = ' ';
-                        line[hexColumn + 1] = ' ';
-                        line[charColumn] = ' ';
+                        Console.Write($"{bytes[offset + i]:X2} ");
                     }
                     else
                     {
-                        var b = bytes[i + j];
-
-                        line[hexColumn] = hexChars[(b >> 4) & 0xF];
-                        line[hexColumn + 1] = hexChars[b & 0xF];
-                        line[charColumn] = (b < 32 ? '·' : (char)b);
+                        Console.Write("   ");
                     }
 
-                    hexColumn += 3;
-                    charColumn++;
+                    if (i == 7)
+                    {
+                        Console.Write(" ");
+                    }
                 }
 
-                result.Append(line);
-            }
+                Console.Write("  ");
 
-            Console.WriteLine(result.ToString());
+                // Print 16 bytes as ASCII printable chars
+                for (int i = 0; i < 16; i++)
+                {
+                    if (offset + i < bytes.Length)
+                    {
+                        char ch = (char)bytes[offset + i];
+                        Console.Write(char.IsControl(ch) ? '.' : ch);
+                    }
+                    else
+                    {
+                        Console.Write(" ");
+                    }
+                }
+
+                Console.WriteLine();
+                offset += 16;
+            }
         }
     }
 }

--- a/ThreatCheck/ThreatCheck/Core/Scanner.cs
+++ b/ThreatCheck/ThreatCheck/Core/Scanner.cs
@@ -29,7 +29,7 @@ namespace ThreatCheck
                     Buffer.BlockCopy(originalarray, originalarray.Length - 256, offendingBytes, 0, 256);
                 }
 
-                Helpers.HexDump(offendingBytes);
+                Helpers.HexDump(offendingBytes, originalarray.Length);
                 Complete = true;
             }
 


### PR DESCRIPTION
This merge requests implements correct labeling of the hex output, regarding the found malicious block and its appearance. See the left-side oft the following screenshots as an example:

Before:
![image](https://github.com/rasta-mouse/ThreatCheck/assets/163165366/3e63d6a1-4e57-4ae2-8742-d6e39e56f601)

After:
![image](https://github.com/rasta-mouse/ThreatCheck/assets/163165366/1178dfe8-bc5a-48e8-94cf-0d30924dd6c0)






Further, the commit simplifies the implementation of the hex dumping method.