### PR TITLE
Updated so that local scripts are decoded from Unicode strings to ensure proper detections 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ C:\>ThreatCheck.exe --help
   -e, --engine    (Default: Defender) Scanning engine. Options: Defender, AMSI
   -f, --file      Analyze a file on disk
   -u, --url       Analyze a file from a URL
+  -t, --type      File type to scan. Options: Bin, Script
   --help          Display this help screen.
   --version       Display version information.
 ```
@@ -34,4 +35,26 @@ C:\Users\Rasta>ThreatCheck.exe -f Downloads\Grunt.bin -e AMSI
 000000D0   00 7D 00 22 00 2C 00 22  00 45 00 6E 00 63 00 72   ·}·"·,·"·E·n·c·r
 000000E0   00 79 00 70 00 74 00 65  00 64 00 4D 00 65 00 73   ·y·p·t·e·d·M·e·s
 000000F0   00 73 00 61 00 67 00 65  00 22 00 3A 00 22 00 7B   ·s·a·g·e·"·:·"·{
+```
+```text
+C:\Users\Rasta>ThreatCheck.exe -f Downloads\launcher.ps1 -e AMSI -t Script
+[+] Target file size: 2988 bytes
+[+] Analyzing...
+[!] Identified end of bad bytes at offset 0x175
+00000000   00 6C 00 79 00 2E 00 47  00 45 00 74 00 54 00 79   ·l·y·.·G·E·t·T·y
+00000010   00 50 00 45 00 28 00 27  00 53 00 79 00 73 00 74   ·P·E·(·'·S·y·s·t
+00000020   00 65 00 6D 00 2E 00 4D  00 61 00 6E 00 61 00 67   ·e·m·.·M·a·n·a·g
+00000030   00 65 00 6D 00 65 00 6E  00 74 00 2E 00 41 00 75   ·e·m·e·n·t·.·A·u
+00000040   00 74 00 6F 00 6D 00 61  00 74 00 69 00 6F 00 6E   ·t·o·m·a·t·i·o·n
+00000050   00 2E 00 41 00 6D 00 73  00 69 00 27 00 2B 00 27   ·.·A·m·s·i·'·+·'
+00000060   00 55 00 74 00 69 00 6C  00 73 00 27 00 29 00 3B   ·U·t·i·l·s·'·)·;
+00000070   00 0D 00 0A 00 24 00 52  00 65 00 66 00 2E 00 47   ·····$·R·e·f·.·G
+00000080   00 65 00 54 00 46 00 49  00 65 00 4C 00 64 00 28   ·e·T·F·I·e·L·d·(
+00000090   00 27 00 61 00 6D 00 73  00 69 00 49 00 6E 00 69   ·'·a·m·s·i·I·n·i
+000000A0   00 74 00 46 00 27 00 2B  00 27 00 61 00 69 00 6C   ·t·F·'·+·'·a·i·l
+000000B0   00 65 00 64 00 27 00 2C  00 27 00 4E 00 6F 00 6E   ·e·d·'·,·'·N·o·n
+000000C0   00 50 00 75 00 62 00 6C  00 69 00 63 00 2C 00 53   ·P·u·b·l·i·c·,·S
+000000D0   00 74 00 61 00 74 00 69  00 63 00 27 00 29 00 2E   ·t·a·t·i·c·'·)·.
+000000E0   00 53 00 65 00 74 00 56  00 61 00 6C 00 75 00 65   ·S·e·t·V·a·l·u·e
+000000F0   00 28 00 24 00 4E 00 75  00 4C 00 6C 00 2C 00 24   ·(·$·N·u·L·l·,·$
 ```

--- a/ThreatCheck/ThreatCheck/Amsi/AmsiInstance.cs
+++ b/ThreatCheck/ThreatCheck/Amsi/AmsiInstance.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Net;
 using System.Text;
+using System.Management.Automation;
+using System.Management.Automation.Language;
 
 using static ThreatCheck.NativeMethods;
 
@@ -12,7 +15,7 @@ namespace ThreatCheck
 
         byte[] FileBytes;
 
-        public AmsiInstance(string appName = "ThreatCheck")
+        public AmsiInstance(string appName = "PowerShell_C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe_5.1.22621.2506")
         {
             AmsiInitialize(appName, out AmsiContext);
             AmsiOpenSession(AmsiContext, out AmsiSession);
@@ -21,9 +24,14 @@ namespace ThreatCheck
         public void AnalyzeBytes(byte[] bytes)
         {
             FileBytes = bytes;
+            /*Console.WriteLine("creating script extent");
+            string script = System.Text.Encoding.UTF8.GetString(bytes);
+            ScriptBlockAst Block1 = (ScriptBlockAst)ScriptBlock.Create(script).Ast;
+            Console.WriteLine(Block1.Extent.Text);
+            FileBytes = System.Text.Encoding.Unicode.GetBytes(Block1.Extent.Text);*/
 
             var status = ScanBuffer(FileBytes);
-
+            Console.WriteLine("status value: " + status);
             if (status != AMSI_RESULT.AMSI_RESULT_DETECTED)
             {
                 CustomConsole.WriteOutput("No threat found!");
@@ -72,13 +80,14 @@ namespace ThreatCheck
 
         AMSI_RESULT ScanBuffer(byte[] buffer)
         {
-            AmsiScanBuffer(AmsiContext, buffer, (uint)buffer.Length, "sample", AmsiSession, out AMSI_RESULT result);
+            AmsiScanBuffer(AmsiContext, buffer, (uint)buffer.Length, "", AmsiSession, out AMSI_RESULT result);
             return result;
         }
 
         AMSI_RESULT ScanBuffer(byte[] buffer, IntPtr session)
         {
-            AmsiScanBuffer(AmsiContext, buffer, (uint)buffer.Length, "sample", session, out AMSI_RESULT result);
+            
+            AmsiScanBuffer(AmsiContext, buffer, (uint)buffer.Length, "", session, out AMSI_RESULT result);
             return result;
         }
 

--- a/ThreatCheck/ThreatCheck/Amsi/AmsiInstance.cs
+++ b/ThreatCheck/ThreatCheck/Amsi/AmsiInstance.cs
@@ -15,6 +15,8 @@ namespace ThreatCheck
 
         byte[] FileBytes;
 
+        //The appName appears to matter in the detections that will occur especially for scripts. Giving it a powershell app appears to be the most 
+        //aggresive in producing detections so use that as the default.
         public AmsiInstance(string appName = "PowerShell_C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe_5.1.22621.2506")
         {
             AmsiInitialize(appName, out AmsiContext);
@@ -24,11 +26,6 @@ namespace ThreatCheck
         public void AnalyzeBytes(byte[] bytes)
         {
             FileBytes = bytes;
-            /*Console.WriteLine("creating script extent");
-            string script = System.Text.Encoding.UTF8.GetString(bytes);
-            ScriptBlockAst Block1 = (ScriptBlockAst)ScriptBlock.Create(script).Ast;
-            Console.WriteLine(Block1.Extent.Text);
-            FileBytes = System.Text.Encoding.Unicode.GetBytes(Block1.Extent.Text);*/
 
             var status = ScanBuffer(FileBytes);
             Console.WriteLine("status value: " + status);

--- a/ThreatCheck/ThreatCheck/App.config
+++ b/ThreatCheck/ThreatCheck/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/ThreatCheck/ThreatCheck/App.config
+++ b/ThreatCheck/ThreatCheck/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
     </startup>
 </configuration>

--- a/ThreatCheck/ThreatCheck/Core/Scanner.cs
+++ b/ThreatCheck/ThreatCheck/Core/Scanner.cs
@@ -2,46 +2,39 @@
 
 namespace ThreatCheck
 {
+//there was an issue with array handling when scanning small scripts. ChatGPT fixed it 
     class Scanner
     {
         public static bool Malicious = false;
         public static bool Complete = false;
 
-        public virtual byte[] HalfSplitter(byte[] originalarray, int lastgood)
+        public virtual byte[] HalfSplitter(byte[] originalArray, int lastGood)
         {
-            var splitArray = new byte[(originalarray.Length - lastgood) / 2 + lastgood];
+            int splitSize = (originalArray.Length - lastGood) / 2 + lastGood;
+            var splitArray = new byte[splitSize];
 
-            if (originalarray.Length == splitArray.Length + 1)
+            if (originalArray.Length == splitSize + 1)
             {
-                var msg = string.Format("Identified end of bad bytes at offset 0x{0:X}", originalarray.Length);
-
+                var msg = $"Identified end of bad bytes at offset 0x{originalArray.Length:X}";
                 CustomConsole.WriteThreat(msg);
 
-                byte[] offendingBytes = new byte[256];
-
-                if (originalarray.Length < 256)
-                {
-                    Array.Resize(ref offendingBytes, originalarray.Length);
-                    Buffer.BlockCopy(originalarray, originalarray.Length, offendingBytes, 0, originalarray.Length);
-                }
-                else
-                {
-                    Buffer.BlockCopy(originalarray, originalarray.Length - 256, offendingBytes, 0, 256);
-                }
+                int offendingSize = Math.Min(originalArray.Length, 256);
+                var offendingBytes = new byte[offendingSize];
+                Buffer.BlockCopy(originalArray, originalArray.Length - offendingSize, offendingBytes, 0, offendingSize);
 
                 Helpers.HexDump(offendingBytes);
                 Complete = true;
             }
 
-            Array.Copy(originalarray, splitArray, splitArray.Length);
+            Array.Copy(originalArray, splitArray, splitArray.Length);
             return splitArray;
         }
 
-        public virtual byte[] Overshot(byte[] originalarray, int splitarraysize)
+        public virtual byte[] Overshot(byte[] originalArray, int splitArraySize)
         {
-            var newsize = (originalarray.Length - splitarraysize) / 2 + splitarraysize;
+            int newSize = (originalArray.Length - splitArraySize) / 2 + splitArraySize;
 
-            if (newsize.Equals(originalarray.Length - 1))
+            if (newSize == originalArray.Length - 1)
             {
                 Complete = true;
 
@@ -51,10 +44,10 @@ namespace ThreatCheck
                 }
             }
 
-            var newarray = new byte[newsize];
-            Buffer.BlockCopy(originalarray, 0, newarray, 0, newarray.Length);
+            var newArray = new byte[newSize];
+            Buffer.BlockCopy(originalArray, 0, newArray, 0, newSize);
 
-            return newarray;
+            return newArray;
         }
     }
 }

--- a/ThreatCheck/ThreatCheck/PInvoke/NativeMethods.cs
+++ b/ThreatCheck/ThreatCheck/PInvoke/NativeMethods.cs
@@ -18,7 +18,7 @@ namespace ThreatCheck
         public static extern void AmsiUninitialize(IntPtr amsiContext);
 
         [DllImport("amsi.dll", EntryPoint = "AmsiScanBuffer", CallingConvention = CallingConvention.StdCall)]
-        public static extern int AmsiScanBuffer(IntPtr amsiContext, byte[] buffer, uint length, string contentName, IntPtr session, out AMSI_RESULT result);
+        public static extern int AmsiScanBuffer(IntPtr amsiContext, byte[] buffer, uint length, [MarshalAs(UnmanagedType.LPWStr)] string contentName, IntPtr session, out AMSI_RESULT result);
 
         public enum AMSI_RESULT
         {

--- a/ThreatCheck/ThreatCheck/Program.cs
+++ b/ThreatCheck/ThreatCheck/Program.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Security.Cryptography;
 
 namespace ThreatCheck
 {
@@ -20,6 +21,9 @@ namespace ThreatCheck
 
             [Option('u', "url", Required = false, HelpText = "Analyze a file from a URL")]
             public string InUrl { get; set; }
+
+            [Option('t', "filetype", Default = "Bin", Required = false, HelpText = "File type to scan. Options: Bin, Script")]
+            public string FileType { get; set; }
         }
 
         public enum ScanningEngine
@@ -45,14 +49,15 @@ namespace ThreatCheck
 
         static void RunOptions(Options opts)
         {
-            var file = new byte[] { };
+            byte[] fileContent = null;
+            string scriptContent = null;           
             var engine = (ScanningEngine)Enum.Parse(typeof(ScanningEngine), opts.Engine, true);
 
             if (!string.IsNullOrEmpty(opts.InUrl))
             {
                 try
                 {
-                    file = DownloadFile(opts.InUrl);
+                   fileContent = DownloadFile(opts.InUrl);
                 }
                 catch
                 {
@@ -63,9 +68,15 @@ namespace ThreatCheck
             }
             else if (!string.IsNullOrEmpty(opts.InFile))
             {
-                if (File.Exists(opts.InFile))
+                if (File.Exists(opts.InFile) && opts.FileType =="Bin")
                 {
-                    file = File.ReadAllBytes(opts.InFile);
+                    Console.WriteLine("getting bytes");
+                    fileContent = File.ReadAllBytes(opts.InFile);
+                }
+                else if(File.Exists(opts.InFile) && opts.FileType == "Script")
+                {
+                    Console.WriteLine("getting string");
+                    scriptContent = File.ReadAllText(opts.InFile);
                 }
                 else
                 {
@@ -82,10 +93,28 @@ namespace ThreatCheck
             switch (engine)
             {
                 case ScanningEngine.Defender:
-                    ScanWithDefender(file);
+                    Console.WriteLine("Scanning with Defender");
+                    if (fileContent != null)
+                    {
+                        ScanWithDefender(fileContent);
+                    }
+                    else
+                    {
+                        Console.WriteLine("scritps don't work with defender yet");
+                    }
+                    
+                    
                     break;
                 case ScanningEngine.Amsi:
-                    ScanWithAmsi(file);
+                    Console.WriteLine("scanning with AMSI");
+                    if (fileContent != null)
+                    {
+                        ScanWithAmsi(fileContent);
+                    }
+                    else
+                    {
+                        ScanWithAmsi(scriptContent);
+                    }                    
                     break;
                 default:
                     break;
@@ -99,7 +128,7 @@ namespace ThreatCheck
                 Console.Error.WriteLine(err.ToString());
             }
         }
-
+      
         static byte[] DownloadFile(string url)
         {
             using (var client = new WebClient())
@@ -123,9 +152,25 @@ namespace ThreatCheck
                     CustomConsole.WriteError("Ensure real-time protection is enabled");
                     return;
                 }
-
                 amsi.AnalyzeBytes(file);
             }
         }
+        //There was an issue with the way bytes were converted when using File.ReadAllBytes
+        //that causedd the bytes to not properly match signatures compared to when being ran. 
+        //The string has be decode from unicode in order to get proper detections 
+        static void ScanWithAmsi(string file)
+        {
+            
+            byte[] filebytes = System.Text.Encoding.Unicode.GetBytes(file);
+            using (var amsi = new AmsiInstance())
+            {
+                if (!amsi.RealTimeProtectionEnabled)
+                {
+                    CustomConsole.WriteError("Ensure real-time protection is enabled");
+                    return;
+                }
+                amsi.AnalyzeBytes(filebytes);
+            }
+        } 
     }
 }

--- a/ThreatCheck/ThreatCheck/Program.cs
+++ b/ThreatCheck/ThreatCheck/Program.cs
@@ -22,7 +22,7 @@ namespace ThreatCheck
             [Option('u', "url", Required = false, HelpText = "Analyze a file from a URL")]
             public string InUrl { get; set; }
 
-            [Option('t', "filetype", Default = "Bin", Required = false, HelpText = "File type to scan. Options: Bin, Script")]
+            [Option('t', "type", Default = "Bin", Required = false, HelpText = "File type to scan. Options: Bin, Script")]
             public string FileType { get; set; }
         }
 

--- a/ThreatCheck/ThreatCheck/Program.cs
+++ b/ThreatCheck/ThreatCheck/Program.cs
@@ -70,12 +70,10 @@ namespace ThreatCheck
             {
                 if (File.Exists(opts.InFile) && opts.FileType =="Bin")
                 {
-                    Console.WriteLine("getting bytes");
                     fileContent = File.ReadAllBytes(opts.InFile);
                 }
                 else if(File.Exists(opts.InFile) && opts.FileType == "Script")
                 {
-                    Console.WriteLine("getting string");
                     scriptContent = File.ReadAllText(opts.InFile);
                 }
                 else
@@ -93,7 +91,6 @@ namespace ThreatCheck
             switch (engine)
             {
                 case ScanningEngine.Defender:
-                    Console.WriteLine("Scanning with Defender");
                     if (fileContent != null)
                     {
                         ScanWithDefender(fileContent);
@@ -106,7 +103,7 @@ namespace ThreatCheck
                     
                     break;
                 case ScanningEngine.Amsi:
-                    Console.WriteLine("scanning with AMSI");
+                    
                     if (fileContent != null)
                     {
                         ScanWithAmsi(fileContent);
@@ -156,8 +153,8 @@ namespace ThreatCheck
             }
         }
         //There was an issue with the way bytes were converted when using File.ReadAllBytes
-        //that causedd the bytes to not properly match signatures compared to when being ran. 
-        //The string has be decode from unicode in order to get proper detections 
+        //that causedd the bytes to not properly match signatures compared to when being executed. 
+        //The string has be decoded from unicode in order to get proper detections 
         static void ScanWithAmsi(string file)
         {
             

--- a/ThreatCheck/ThreatCheck/ThreatCheck.csproj
+++ b/ThreatCheck/ThreatCheck/ThreatCheck.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ThreatCheck</RootNamespace>
     <AssemblyName>ThreatCheck</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
@@ -39,6 +41,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.PowerShell.5.ReferenceAssemblies.1.1.0\lib\net4\System.Management.Automation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/ThreatCheck/ThreatCheck/ThreatCheck.csproj
+++ b/ThreatCheck/ThreatCheck/ThreatCheck.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ThreatCheck</RootNamespace>
     <AssemblyName>ThreatCheck</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.2.8.0\lib\net40\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.9.1.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.9.1\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ThreatCheck/ThreatCheck/packages.config
+++ b/ThreatCheck/ThreatCheck/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.8.0" targetFramework="net40" />
+  <package id="CommandLineParser" version="2.9.1" targetFramework="net47" />
   <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0" targetFramework="net48" />
   <package id="System.Management.Automation" version="7.4.2" targetFramework="net48" />
 </packages>

--- a/ThreatCheck/ThreatCheck/packages.config
+++ b/ThreatCheck/ThreatCheck/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="2.8.0" targetFramework="net40" />
+  <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0" targetFramework="net48" />
+  <package id="System.Management.Automation" version="7.4.2" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
AMSI will only detect on PowerShell scripts and other scripting languages when decoded from Unicode strings. This was not occurring when using FIle.ReadAllBytes. So created a switch to tell ThreatCheck to use ReadAllText when using local scripts. 

Additionally AMSI appears to use the app name passed in to determine how aggressive to be in detections. During testing passing in a valid Powershell app name as done in the PowerShell project [here ](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/security/SecuritySupport.cs#L1364) appears to generate the most aggressive detection. As a result, updated that to be the default appName passed in. 